### PR TITLE
Add Install.cmd and fix relative path issues in Install.ps1

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A music downloader mod for the Windows Spotify client
 
 # Installation and Usage
 1. Download and extract the `.zip` package of the [latest release](https://github.com/Rafiuth/Soggfy/releases/latest).
-2. Right click the `Install.ps1` file, then select "Run with PowerShell". If it prompts about execution policy, enter `Y` to allow. Wait for it to finish.
+2. Double click the `Install.cmd` file. It will run the Install.ps1 script with Execution Policy Bypass. Wait for it to finish.
 3. Run `Injector.exe`, and wait for Spotify to open.
 4. Play the songs you want to download.
 

--- a/SpotifyOggDumper/Data/Install.cmd
+++ b/SpotifyOggDumper/Data/Install.cmd
@@ -1,0 +1,1 @@
+powershell.exe -executionpolicy bypass -file ".\Install.ps1"


### PR DESCRIPTION
Install.ps1 uses relative paths for all its file operations. However, in certain circumstances, this relative path points to C;\Windows\System32 (or whatever the system drive letter is). This is independent of the current working directory, so `Set-Location -Path $PWD.Path` does not affect that behaviour. The solution is to change all relative paths to absolute paths.

Also, many user complain that the script opens and exits immediately, which is due to the execution policy not being set. Setting the execution policy globally is a very bad idea, so you should never, ever run `set-executionpolicy unrestricted`. If at all you should run `set-executionpolicy unrestricted -Scope process`.
However, a more convenient way is to use a wrapper batch script to do that for you, as you can see in Install.cmd. This will start powershell with an execution policy "bypass" so it's only for the lifetime of the installation.