### PR TITLE
Fix Uninstall.cmd

### DIFF
--- a/Scripts/Uninstall.cmd
+++ b/Scripts/Uninstall.cmd
@@ -1,5 +1,5 @@
-del %appdata%\Spotify\dpapi.dll
-del %appdata%\Spotify\SoggfyUIC.js
-rmdir /q /s %localappdata%\Soggfy
+del "%appdata%\Spotify\dpapi.dll"
+del "%appdata%\Spotify\SoggfyUIC.js"
+rmdir /q /s "%localappdata%\Soggfy"
 
 pause


### PR DESCRIPTION
Fix Uninstall.cmd when user directory contains a space.