### PR TITLE
Add check to reuse or re-download Spotify installer if file exists

### DIFF
--- a/Scripts/Install.ps1
+++ b/Scripts/Install.ps1
@@ -28,7 +28,17 @@ function CheckOrInstallSpotify {
 
         Get-AppxPackage -Name SpotifyAB.SpotifyMusic | Remove-AppxPackage
     }
-    DownloadFile -Url $SpotifyInstallerUrl -DestPath "$temp\SpotifyInstaller-$SpotifyVersion.exe"
+
+	# Check if installer is already downloaded
+	if (Test-Path "$temp\SpotifyInstaller-$SpotifyVersion.exe") {
+		# Ask user if they want to reuse the existing download
+		if ((Read-Host -Prompt "Use existing downloaded Spotify installer? Y/N") -ne "y") {
+			DownloadFile -Url $SpotifyInstallerUrl -DestPath "$temp\SpotifyInstaller-$SpotifyVersion.exe"
+		}
+	}
+	else {
+		DownloadFile -Url $SpotifyInstallerUrl -DestPath "$temp\SpotifyInstaller-$SpotifyVersion.exe"
+	}
 
     Write-Host "Installing..."
 


### PR DESCRIPTION
This PR updates the PowerShell script to check if the Spotify installer already exists in the temporary directory.
- If the installer is found, users are prompted to either use this existing installer or to re-download a fresh copy.
- If the installer is not present, the installer is downloaded automatically.